### PR TITLE
add gdb

### DIFF
--- a/environments/py3.10/m3-4.9.2/jaspy3.10-m3-4.9.2-r20220721/core_packages.yml
+++ b/environments/py3.10/m3-4.9.2/jaspy3.10-m3-4.9.2-r20220721/core_packages.yml
@@ -229,6 +229,7 @@ dependencies:
     - scandir
     - spectral
     - dask-gateway
+    - gdb
 # pooch needed for xarray tests
     - pooch
 

--- a/environments/py3.10/m3-4.9.2/jaspy3.10-m3-4.9.2-r20220721/initial.yml
+++ b/environments/py3.10/m3-4.9.2/jaspy3.10-m3-4.9.2-r20220721/initial.yml
@@ -135,6 +135,7 @@ dependencies:
   - gcc_impl_linux-64=12.1.0=hea43390_16
   - gcc_linux-64=12.1.0=h3bb4806_10
   - gdal=3.4.1=py310h222ae0d_2
+  - gdb=11.2=py310he3c4487_2
   - gdk-pixbuf=2.42.8=hff1cb4f_0
   - geopandas=0.11.0=pyhd8ed1ab_0
   - geopandas-base=0.11.0=pyha770c72_0


### PR DESCRIPTION
This pull requests adds gdb.

When I tried to resolve the _existing_ environment, I am currently finding that mamba is now installing pip packages instead of a fair number of the conda packages (whether starting from `core_packages.yml` or `initial.yml`), which is not a problem that existed before, and which means that the usual check of whether I can reexport and recover the original initial.yml file fails.

Although I don't know why this is happening, what I can see is that if I add the `gdb` requirement when installing from `core_packages.yml`, the only difference between the environment this produces and the same thing without the gdb requirement is that the gdb package itself is added; nothing else needs to be installed or updated for dependencies.

For this reason, this pull request contains a hand-edit to the previously exported `initial.yml` in order to add the `gdb` package itself at the version that mamba chooses when I do the above.  In other words, the new `initial.yml` is not the output of a `conda env export` as it usually would be, as this would have a lot of packages changed to pip packages as described above.

The environment successfully adds the gdb executable, and I have checked that it can handle object code from the gcc / gfortran version that is in Jaspy, which is the motivation for adding it.

I also find that the change does not introduce any failures in the quick software tests, other than that gdb introduces a new file `libpython.py` in the `site-packages` directory, and `test_all_imports` finds this and reports that `import libpython` doesn't work (it contains `import gdb` and there is no `gdb` python package).  But this might or might not be a valid thing to do anyway, and I haven't had time to work out how you are supposed to use the gdb python extension, so I can't really test that aspect (though there's some docs [here](https://sourceware.org/gdb/current/onlinedocs/gdb/Python.html)). This could be a thing to address later if people want that functionality and something else is required to make it work, but it is not a reason against adding gdb now for sake of C/Fortran code.